### PR TITLE
Fixing the fortnite script - Outdated

### DIFF
--- a/fortnite-tga-slice.py
+++ b/fortnite-tga-slice.py
@@ -28,7 +28,7 @@ mapIdentifier = args.map.lower()
 if mapIdentifier not in  { 'athena' }:
     sys.exit('unknown map identifier \'' + mapIdentifier + '\'')
 
-numTiles = 132 # 10²
+numTiles = 144 # 10²
 
 
 assert os.path.isdir(args.umodel_export_path)
@@ -55,7 +55,6 @@ tile_height = { 0: 128 }[lod]
 # tile_offset = int({ 0: 0, 1: 512 * 512 * 4 * (1.0), 2: 512 * 512 * 4 * (1.0 + 0.25)}[lod])
 
 tile_scale = 12;
-tile_scale_y = 11;
 tile_size = int(tile_width * tile_height)
 # tile_size_with_mipmaps = int(tile_size * tile_channels * (1.00 + 0.25 + 0.0625))
 
@@ -130,8 +129,8 @@ def extract_tiles(asset_path, offsets, height_target, normal_target):
 
 print ('extracting', numTiles, 'tiles (normal and height data) ...')
 
-normal_composite = Image.new("RGB", (tile_width * tile_scale, tile_height * tile_scale_y))
-height_composite = Image.new("I", (tile_width * tile_scale, tile_height * tile_scale_y))
+normal_composite = Image.new("RGB", (tile_width * tile_scale, tile_height * tile_scale))
+height_composite = Image.new("I", (tile_width * tile_scale, tile_height * tile_scale))
 
 
 athena_indices = {
@@ -197,7 +196,7 @@ normal_composite.save(normal_stitched_path, 'PNG', compress_level = min(9, compr
 
 if args.thumbnail:
 	normal_stitched_path = os.path.join(output_path, 'fortnite_' + mapIdentifier + '_' + normal_semantic + '_preview.png')
-	normal_composite.thumbnail((704, 768), Image.BILINEAR)
+	normal_composite.thumbnail((512, 512), Image.BILINEAR)
 	normal_composite.save(normal_stitched_path, 'PNG', compress_level = min(9, compress), optimize = compress == 10)
 
 
@@ -208,5 +207,5 @@ height_composite.save(height_stitched_path, 'PNG', compress_level = min(9, compr
 
 if args.thumbnail:
 	height_stitched_path = os.path.join(output_path, 'fortnite_' + mapIdentifier + '_' + height_semantic + '_preview.png')
-	height_composite.thumbnail((704, 768), Image.BILINEAR)
+	height_composite.thumbnail((512, 512), Image.BILINEAR)
 	height_composite.save(height_stitched_path, 'PNG', compress_level = min(9, compress), optimize = compress == 10)

--- a/fortnite-tga-slice.py
+++ b/fortnite-tga-slice.py
@@ -28,7 +28,7 @@ mapIdentifier = args.map.lower()
 if mapIdentifier not in  { 'athena' }:
     sys.exit('unknown map identifier \'' + mapIdentifier + '\'')
 
-numTiles = 100 # 10²
+numTiles = 132 # 10²
 
 
 assert os.path.isdir(args.umodel_export_path)
@@ -54,7 +54,8 @@ tile_height = { 0: 128 }[lod]
 # tile_channels = 4
 # tile_offset = int({ 0: 0, 1: 512 * 512 * 4 * (1.0), 2: 512 * 512 * 4 * (1.0 + 0.25)}[lod])
 
-tile_scale = 10;
+tile_scale = 12;
+tile_scale_y = 11;
 tile_size = int(tile_width * tile_height)
 # tile_size_with_mipmaps = int(tile_size * tile_channels * (1.00 + 0.25 + 0.0625))
 
@@ -129,50 +130,48 @@ def extract_tiles(asset_path, offsets, height_target, normal_target):
 
 print ('extracting', numTiles, 'tiles (normal and height data) ...')
 
-normal_composite = Image.new("RGB", (tile_width * tile_scale, tile_height * tile_scale))
-height_composite = Image.new("I", (tile_width * tile_scale, tile_height * tile_scale))
+normal_composite = Image.new("RGB", (tile_width * tile_scale, tile_height * tile_scale_y))
+height_composite = Image.new("I", (tile_width * tile_scale, tile_height * tile_scale_y))
 
 
 athena_indices = {
-	1: {
-		 0: (2, 4),  1: (3, 4),  2: (4, 4),  3: (5, 4), 
-		             5: (3, 5),  6: (4, 5),  7: (5, 5), 
-		                        10: (4, 6), 11: (5, 6), 
-		                                    15: (5, 7) 
+	0: {
+            
+		 0: (1, 2), 1: (0, 2), 2: (0, 1), 3: (1, 1), 4: (0, 0), 5: (1, 0),
+                 10: (6, 1), 14: (6, 2), 9: (6, 0), 13: (7, 2), 15: (6, 3), 12: (7, 1),
+                 6: (7, 0), 28: (4, 3), 16: (5, 3), 29: (3, 3), 30: (3, 4), 31: (4, 4),
+                 32: (2, 3), 33: (2, 4), 34: (3, 2), 35: (4, 2), 36: (5, 2), 37: (5, 1),
+                 
 		},
-	2: { 
-		                                    23: (3, 1), 
-		            11: (1, 2), 
-                                24: (2, 2), 25: (3, 2), 
-		14: (0, 3), 15: (1, 3), 26: (2, 3), 27: (3, 3), 
-		28: (0, 4), 31: (1, 4) 
-		},
-	3: { 
-		21: (4, 0), 22: (5, 0),  5: (6, 0),  6: (7, 0),  7: (8, 0),
-		24: (4, 1), 23: (5, 1),  9: (6, 1), 10: (7, 1), 11: (8, 1), 12: (9, 1), 
-		30: (4, 2), 28: (5, 2), 13: (6, 2), 14: (7, 2), 15: (8, 2), 16: (9, 2), 
-		31: (4, 3), 29: (5, 3), 17: (6, 3), 18: (7, 3), 19: (8, 3), 20: (9, 3),
-		                        27: (6, 4), 26: (7, 4), 25: (8, 4),  4: (9, 4),  
-		                         3: (6, 5),  2: (7, 5),  1: (8, 5),  0: (9, 5),
-		},
-	4: {
-	    45: (0, 5), 49: (1, 5), 52: (2, 5),
-		21: (0, 6), 24: (1, 6), 42: (2, 6), 39: (3, 6),
-		            23: (1, 7),  0: (2, 7), 26: (3, 7), 36: (4, 7),	
-		             8: (1, 8), 27: (2, 8),
-		                        32: (2, 9),	    
-		},
-	5: {
-								            23: (6, 6), 24: (7, 6), 25: (8, 6), 26: (9, 6),
-						                    27: (6, 7), 28: (7, 7), 29: (8, 7), 30: (9, 7),
-		39: (3, 8), 21: (4, 8),  4: (5, 8),  7: (6, 8),  8: (7, 8),  9: (8, 8), 10: (9, 8),
-		37: (3, 9),  2: (4, 9),  5: (5, 9), 11: (6, 9), 12: (7, 9), 13: (8, 9),	
-	    
-	    
-	    
-		
-		},
+        1: {
+            
+                 1: (5, 4), 2: (6, 4), 3: (7, 4), 5: (5, 5), 6: (6, 5), 7: (7, 5),
+                 10: (6, 6), 11: (7, 6), 15: (7, 7),
+                 
+                },
+        3: {
 
+                0: (11, 5), 1: (10, 5), 2: (9, 5), 3: (8, 5), 4: (11, 4), 5: (8, 0),
+                6: (9, 0), 7: (10, 0), 9: (8, 1), 10: (9, 1), 11: (10, 1), 12: (11, 1),
+                13: (8, 2), 14: (9, 2), 15: (10, 2), 16: (11, 2), 17: (8, 3), 18: (9, 3),
+                19: (10, 3), 20: (11, 3), 25: (10, 4), 26: (9, 4), 27: (8, 4), 29: (7, 3),
+                
+                },
+        4: {
+            
+                0: (4, 7), 8: (3, 8), 21: (2, 6), 23: (3, 7), 24: (3, 6), 26: (5, 7), 
+                27: (4, 8), 32: (4, 9), 36: (6, 7), 39: (5, 6), 42: (4, 6), 45: (2, 5),
+                49: (3, 5), 52: (4, 5),
+                
+                },
+        5: {
+
+                2: (6, 9), 4: (7, 8), 5: (7, 9), 7: (8, 8), 8: (9, 8), 9: (10, 8),
+                10: (11, 8), 11: (8, 9), 12: (9, 9), 13: (10, 9), 21: (6, 8), 23: (8, 6),
+                24: (9, 6), 25: (10, 6), 26: (11, 6), 27: (8, 7), 28: (9, 7), 29: (10, 7),
+                30: (11, 7), 37: (5, 9), 39: (5, 8)
+
+                }
 }
 
 
@@ -189,7 +188,7 @@ for key in offset_lookup.keys():
 	extract_tiles(asset_path, offset_lookup[key], height_composite, normal_composite)
 
 
-map_size_info  = ['1.2k'][0]
+map_size_info  = ['1.536k'][0]
 
 normal_stitched_path = os.path.join(output_path, 'fortnite_' + mapIdentifier + '_' + normal_semantic + '_lod' + str(lod) + '.png')
 print (normal_stitched_path, 'saving', map_size_info, 'normal map ... hang in there')
@@ -198,7 +197,7 @@ normal_composite.save(normal_stitched_path, 'PNG', compress_level = min(9, compr
 
 if args.thumbnail:
 	normal_stitched_path = os.path.join(output_path, 'fortnite_' + mapIdentifier + '_' + normal_semantic + '_preview.png')
-	normal_composite.thumbnail((512, 512), Image.BILINEAR)
+	normal_composite.thumbnail((704, 768), Image.BILINEAR)
 	normal_composite.save(normal_stitched_path, 'PNG', compress_level = min(9, compress), optimize = compress == 10)
 
 
@@ -209,5 +208,5 @@ height_composite.save(height_stitched_path, 'PNG', compress_level = min(9, compr
 
 if args.thumbnail:
 	height_stitched_path = os.path.join(output_path, 'fortnite_' + mapIdentifier + '_' + height_semantic + '_preview.png')
-	height_composite.thumbnail((512, 512), Image.BILINEAR)
+	height_composite.thumbnail((704, 768), Image.BILINEAR)
 	height_composite.save(height_stitched_path, 'PNG', compress_level = min(9, compress), optimize = compress == 10)


### PR DESCRIPTION
With recent updates epic rearranged the tiles so the current indices aren't correct. Went ahead and fixed the indices, also corrected the layout as its actually 12x12 ( its confirmed by another texture thats used to map cliffs and grass on the map ) and also to include the starting island.

P.S. sorry for the second commit, I made an oversight and didn't add another empty row.